### PR TITLE
Add bilingual support and executable packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+downloads/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
-# mp3-downloader-key-finder2
+# mp3-downloader-key-finder
+
+This command-line tool downloads a YouTube video, extracts the audio as an MP3
+file (160 kbps or 320 kbps), and then analyzes several musical features of the
+track. It reports the detected key along with its relative (alternate) key and
+basic audio metrics such as BPM, energy, danceability and happiness.
+
+## Usage
+
+```
+python main.py <youtube_url> [--bitrate 160|320] [--lang en|es]
+```
+
+The downloaded file is stored in the `downloads/` directory and the analyzed
+features are printed to the console. Use `--lang` to switch between English
+(`en`) and Spanish (`es`).
+
+## Graphical interface
+
+For a simple GUI with a black/#2F5BF9/white palette, run:
+
+```
+python gui.py [en|es]
+```
+
+The interface lets you choose a download directory, enter a YouTube URL and
+bitrate, or import/drag audio files for analysis. Results show the detected
+key, relative key, BPM, energy, danceability and happiness.
+
+### Requirements
+
+Install dependencies with:
+
+```
+pip install -r requirements.txt
+```
+
+`yt-dlp` relies on `ffmpeg` for conversion to MP3. Ensure `ffmpeg` is available
+on your system.
+
+## Executables
+
+Install `pyinstaller` (included in `requirements.txt`) and run:
+
+```
+python build.py gui  # build GUI executable
+python build.py cli  # build command-line executable
+```
+
+The binaries are placed in the `dist/` directory. Build on the target platform
+(Windows or Linux) to produce native executables.
+
+## Audio metrics
+
+The analysis module reports three additional scores on a 0-100 scale:
+
+- **Energy** – approximates the loudness and intensity of the track using RMS
+  energy. Values near 0 indicate calm or quiet audio, while values near 100
+  represent very energetic material.
+- **Danceability** – derived from onset strength and hints at how suitable a
+  track is for dancing. Higher numbers suggest a more pronounced and stable
+  beat.
+- **Happiness** – uses spectral centroid as a proxy for brightness; lower scores
+  correspond to darker or sadder timbres, whereas higher scores imply brighter,
+  more cheerful sounds.
+
+Interpretation guide: 0–33 → low, 34–66 → medium, 67–100 → high.

--- a/audio_features.py
+++ b/audio_features.py
@@ -1,0 +1,44 @@
+import numpy as np
+import librosa
+from i18n import t
+
+
+def analyze_features(file_path: str) -> dict:
+    """Calculate basic audio features for the given file.
+
+    Returns a dictionary with BPM, energy, danceability and happiness scores.
+    All feature scores are normalised to a 0-100 scale where higher values
+    indicate a stronger presence of that quality.
+    """
+    y, sr = librosa.load(file_path)
+
+    # BPM
+    tempo, _ = librosa.beat.beat_track(y=y, sr=sr)
+
+    # Energy as mean RMS
+    rms = librosa.feature.rms(y=y)[0]
+    energy = float(np.mean(rms) / np.max(rms) * 100) if np.max(rms) > 0 else 0.0
+
+    # Danceability via onset strength
+    onset_env = librosa.onset.onset_strength(y=y, sr=sr)
+    danceability = float(np.mean(onset_env) / np.max(onset_env) * 100) if np.max(onset_env) > 0 else 0.0
+
+    # Happiness via spectral centroid
+    centroid = librosa.feature.spectral_centroid(y=y, sr=sr)[0]
+    happiness = float(np.mean(centroid) / np.max(centroid) * 100) if np.max(centroid) > 0 else 0.0
+
+    return {
+        "bpm": float(tempo),
+        "energy": energy,
+        "danceability": danceability,
+        "happiness": happiness,
+    }
+
+
+def describe_score(value: float) -> str:
+    """Return a qualitative description for a 0-100 feature score."""
+    if value < 33:
+        return t("low")
+    if value < 66:
+        return t("medium")
+    return t("high")

--- a/build.py
+++ b/build.py
@@ -1,0 +1,17 @@
+import PyInstaller.__main__
+import sys
+
+
+def build():
+    target = sys.argv[1] if len(sys.argv) > 1 else 'gui'
+    entry = 'gui.py' if target == 'gui' else 'main.py'
+    name = 'mp3-tool-gui' if target == 'gui' else 'mp3-tool-cli'
+    PyInstaller.__main__.run([
+        entry,
+        '--onefile',
+        '--name', name,
+    ])
+
+
+if __name__ == '__main__':
+    build()

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,207 @@
+import os
+import shutil
+import sys
+
+from tkinter import (
+    filedialog,
+    messagebox,
+    Listbox,
+    Frame,
+    Text,
+    Label,
+    Button,
+    Entry,
+    StringVar,
+    END,
+    BOTH,
+    LEFT,
+    X,
+    NW,
+)
+from tkinter import ttk
+
+try:
+    from tkinterdnd2 import TkinterDnD, DND_FILES
+
+    BaseTk = TkinterDnD.Tk
+    DND_AVAILABLE = True
+except Exception:  # pragma: no cover - tkinterdnd2 optional
+    from tkinter import Tk as BaseTk
+
+    DND_AVAILABLE = False
+
+from youtube_audio import download_audio
+from key_finder import estimate_key
+from audio_features import analyze_features, describe_score
+from i18n import set_language, t
+
+
+class App:
+    """Graphical interface for downloading and analyzing audio."""
+
+    def __init__(self, lang: str = "en") -> None:
+        set_language(lang)
+        self.root = BaseTk()
+        self.root.title(t("app_title"))
+        self.root.configure(bg="black")
+
+        self.download_dir = StringVar(value="downloads")
+
+        # Directory selector
+        dir_frame = Frame(self.root, bg="black")
+        dir_frame.pack(padx=10, pady=10, fill=X)
+        Label(
+            dir_frame, text=t("download_directory"), fg="white", bg="black"
+        ).pack(side=LEFT)
+        Entry(dir_frame, textvariable=self.download_dir, width=40).pack(
+            side=LEFT, padx=5
+        )
+        Button(
+            dir_frame,
+            text=t("browse"),
+            command=self.choose_dir,
+            bg="#2F5BF9",
+            fg="white",
+        ).pack(side=LEFT)
+
+        # URL downloader
+        url_frame = Frame(self.root, bg="black")
+        url_frame.pack(padx=10, pady=10, fill=X)
+        Label(url_frame, text=t("youtube_url"), fg="white", bg="black").pack(side=LEFT)
+        self.url_var = StringVar()
+        Entry(url_frame, textvariable=self.url_var, width=40).pack(side=LEFT, padx=5)
+        self.bitrate_var = StringVar(value="160")
+        ttk.OptionMenu(url_frame, self.bitrate_var, "160", "160", "320").pack(
+            side=LEFT, padx=5
+        )
+        Button(
+            url_frame,
+            text=t("download"),
+            command=self.download_url,
+            bg="#2F5BF9",
+            fg="white",
+        ).pack(side=LEFT)
+
+        # File list
+        list_frame = Frame(self.root, bg="black")
+        list_frame.pack(padx=10, pady=10, fill=BOTH, expand=True)
+        Label(list_frame, text=t("files"), fg="white", bg="black").pack(anchor=NW)
+        self.listbox = Listbox(list_frame, bg="black", fg="white")
+        self.listbox.pack(fill=BOTH, expand=True)
+        Button(
+            list_frame,
+            text=t("analyze_selected"),
+            command=self.analyze_selected,
+            bg="#2F5BF9",
+            fg="white",
+        ).pack(pady=5)
+
+        # Import button
+        Button(
+            self.root,
+            text=t("import_analyze"),
+            command=self.import_file,
+            bg="#2F5BF9",
+            fg="white",
+        ).pack(pady=5)
+
+        # Drag-and-drop area
+        if DND_AVAILABLE:
+            drop_label = Label(
+                self.root,
+                text=t("drop_audio"),
+                fg="white",
+                bg="#2F5BF9",
+                relief="ridge",
+                width=40,
+                height=3,
+            )
+            drop_label.pack(padx=10, pady=10, fill=X)
+            drop_label.drop_target_register(DND_FILES)
+            drop_label.dnd_bind("<<Drop>>", self.drop_file)
+
+        # Results display
+        self.result_text = Text(self.root, height=8, bg="black", fg="white")
+        self.result_text.pack(fill=BOTH, padx=10, pady=10)
+
+        self.refresh_file_list()
+        self.root.mainloop()
+
+    def choose_dir(self) -> None:
+        path = filedialog.askdirectory()
+        if path:
+            self.download_dir.set(path)
+            self.refresh_file_list()
+
+    def refresh_file_list(self) -> None:
+        self.listbox.delete(0, END)
+        directory = self.download_dir.get()
+        if os.path.isdir(directory):
+            for name in sorted(os.listdir(directory)):
+                if name.lower().endswith(".mp3"):
+                    self.listbox.insert(END, name)
+
+    def download_url(self) -> None:
+        url = self.url_var.get().strip()
+        if not url:
+            messagebox.showerror(t("error"), t("enter_url"))
+            return
+        try:
+            bitrate = int(self.bitrate_var.get())
+            path = download_audio(
+                url, bitrate=bitrate, output_dir=self.download_dir.get()
+            )
+            self.refresh_file_list()
+            self.display_features(path)
+        except Exception as exc:  # pragma: no cover - depends on network
+            messagebox.showerror(t("download_error"), str(exc))
+
+    def analyze_selected(self) -> None:
+        selection = self.listbox.curselection()
+        if not selection:
+            messagebox.showinfo(t("info"), t("select_file"))
+            return
+        filename = self.listbox.get(selection[0])
+        path = os.path.join(self.download_dir.get(), filename)
+        self.display_features(path)
+
+    def import_file(self) -> None:
+        filepath = filedialog.askopenfilename(
+            filetypes=[("Audio files", "*.mp3 *.wav *.ogg *.flac")]
+        )
+        if filepath:
+            dest = os.path.join(self.download_dir.get(), os.path.basename(filepath))
+            shutil.copy(filepath, dest)
+            self.refresh_file_list()
+            self.display_features(dest)
+
+    def drop_file(self, event) -> None:  # pragma: no cover - GUI interaction
+        filepath = event.data.strip()
+        if filepath.startswith("{") and filepath.endswith("}"):
+            filepath = filepath[1:-1]
+        if os.path.isfile(filepath):
+            dest = os.path.join(self.download_dir.get(), os.path.basename(filepath))
+            shutil.copy(filepath, dest)
+            self.refresh_file_list()
+            self.display_features(dest)
+
+    def display_features(self, path: str) -> None:
+        key, alt_key = estimate_key(path)
+        feats = analyze_features(path)
+        lines = [
+            f"{t('file')}: {os.path.basename(path)}",
+            f"{t('detected_key')}: {key} ({t('relative_key')}: {alt_key})",
+            f"{t('bpm')}: {feats['bpm']:.2f}",
+            f"{t('energy')}: {feats['energy']:.2f} ({describe_score(feats['energy'])})",
+            f"{t('danceability')}: {feats['danceability']:.2f} ({describe_score(feats['danceability'])})",
+            f"{t('happiness')}: {feats['happiness']:.2f} ({describe_score(feats['happiness'])})",
+            "",
+        ]
+        self.result_text.delete(1.0, END)
+        self.result_text.insert(END, "\n".join(lines))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
+    lang = sys.argv[1] if len(sys.argv) > 1 else "en"
+    App(lang)
+

--- a/i18n.py
+++ b/i18n.py
@@ -1,0 +1,76 @@
+LANG = 'en'
+
+TRANSLATIONS = {
+    'en': {
+        'app_title': 'MP3 Downloader & Analyzer',
+        'download_directory': 'Download directory:',
+        'browse': 'Browse',
+        'youtube_url': 'YouTube URL:',
+        'download': 'Download',
+        'files': 'Files:',
+        'file': 'File',
+        'analyze_selected': 'Analyze Selected',
+        'import_analyze': 'Import and Analyze File',
+        'drop_audio': 'Drop audio file here',
+        'error': 'Error',
+        'enter_url': 'Please enter a YouTube URL.',
+        'download_error': 'Download error',
+        'info': 'Info',
+        'select_file': 'Select a file to analyze.',
+        'cli_description': 'Download YouTube audio and estimate its key',
+        'arg_url': 'YouTube video URL',
+        'arg_output_dir': 'Directory where the MP3 will be saved',
+        'arg_lang': 'Interface language (en or es)',
+        'audio_saved': 'Audio saved to {}',
+        'detected_key': 'Detected key',
+        'relative_key': 'Relative key',
+        'bpm': 'BPM',
+        'energy': 'Energy',
+        'danceability': 'Danceability',
+        'happiness': 'Happiness',
+        'low': 'low',
+        'medium': 'medium',
+        'high': 'high',
+    },
+    'es': {
+        'app_title': 'Descargador MP3 y Analizador',
+        'download_directory': 'Carpeta de descarga:',
+        'browse': 'Buscar',
+        'youtube_url': 'URL de YouTube:',
+        'download': 'Descargar',
+        'files': 'Archivos:',
+        'file': 'Archivo',
+        'analyze_selected': 'Analizar seleccionado',
+        'import_analyze': 'Importar y analizar archivo',
+        'drop_audio': 'Suelta el archivo de audio aquí',
+        'error': 'Error',
+        'enter_url': 'Por favor introduce una URL de YouTube.',
+        'download_error': 'Error de descarga',
+        'info': 'Información',
+        'select_file': 'Selecciona un archivo para analizar.',
+        'cli_description': 'Descarga audio de YouTube y estima su tonalidad',
+        'arg_url': 'URL de video de YouTube',
+        'arg_output_dir': 'Directorio donde se guardará el MP3',
+        'arg_lang': 'Idioma de la interfaz (en o es)',
+        'audio_saved': 'Audio guardado en {}',
+        'detected_key': 'Tonalidad detectada',
+        'relative_key': 'Tonalidad relativa',
+        'bpm': 'BPM',
+        'energy': 'Energía',
+        'danceability': 'Bailabilidad',
+        'happiness': 'Felicidad',
+        'low': 'baja',
+        'medium': 'media',
+        'high': 'alta',
+    }
+}
+
+
+def set_language(lang: str) -> None:
+    global LANG
+    if lang in TRANSLATIONS:
+        LANG = lang
+
+
+def t(key: str) -> str:
+    return TRANSLATIONS.get(LANG, TRANSLATIONS['en']).get(key, key)

--- a/key_finder.py
+++ b/key_finder.py
@@ -1,0 +1,35 @@
+import numpy as np
+import librosa
+
+MAJOR_PROFILE = np.array([6.35, 2.23, 3.48, 2.33, 4.38, 4.09, 2.52, 5.19, 2.39, 3.66, 2.29, 2.88])
+MINOR_PROFILE = np.array([6.33, 2.68, 3.52, 5.38, 2.60, 3.53, 2.54, 4.75, 3.98, 2.69, 3.34, 3.17])
+KEYS = ['C', 'C#', 'D', 'Eb', 'E', 'F', 'F#', 'G', 'Ab', 'A', 'Bb', 'B']
+
+def estimate_key(file_path: str) -> tuple[str, str]:
+    """Estimate the musical key of an audio file and its relative key.
+
+    A simple Krumhansl-Schmuckler-like algorithm is applied to the mean chroma
+    vector of the audio. The function returns both the detected key and the
+    relative ("alternate") key, which is the corresponding relative major or
+    minor.
+    """
+    y, sr = librosa.load(file_path)
+    chroma = librosa.feature.chroma_cqt(y=y, sr=sr)
+    chroma_mean = chroma.mean(axis=1)
+
+    major_scores = [np.corrcoef(np.roll(MAJOR_PROFILE, i), chroma_mean)[0, 1] for i in range(12)]
+    minor_scores = [np.corrcoef(np.roll(MINOR_PROFILE, i), chroma_mean)[0, 1] for i in range(12)]
+
+    best_major = np.argmax(major_scores)
+    best_minor = np.argmax(minor_scores)
+
+    if major_scores[best_major] >= minor_scores[best_minor]:
+        key = f"{KEYS[best_major]} major"
+        alt_idx = (best_major + 9) % 12  # relative minor
+        alt_key = f"{KEYS[alt_idx]} minor"
+    else:
+        key = f"{KEYS[best_minor]} minor"
+        alt_idx = (best_minor + 3) % 12  # relative major
+        alt_key = f"{KEYS[alt_idx]} major"
+
+    return key, alt_key

--- a/main.py
+++ b/main.py
@@ -1,0 +1,37 @@
+import argparse
+from i18n import set_language, t
+from youtube_audio import download_audio
+from key_finder import estimate_key
+from audio_features import analyze_features, describe_score
+
+def main():
+    pre = argparse.ArgumentParser(add_help=False)
+    pre.add_argument("--lang", choices=["en", "es"], default="en")
+    args, remaining = pre.parse_known_args()
+    set_language(args.lang)
+
+    parser = argparse.ArgumentParser(description=t("cli_description"), parents=[pre])
+    parser.add_argument("url", help=t("arg_url"))
+    parser.add_argument("--bitrate", type=int, choices=[160, 320], default=160,
+                        help="Output MP3 bitrate in kbps (160 or 320)")
+    parser.add_argument("--output-dir", default="downloads",
+                        help=t("arg_output_dir"))
+    parser.add_argument("--lang", choices=["en", "es"], default=args.lang,
+                        help=t("arg_lang"))
+    args = parser.parse_args(remaining)
+
+    mp3_path = download_audio(args.url, bitrate=args.bitrate, output_dir=args.output_dir)
+    print(t("audio_saved").format(mp3_path))
+
+    key, alt_key = estimate_key(mp3_path)
+    features = analyze_features(mp3_path)
+
+    print(f"{t('detected_key')}: {key}")
+    print(f"{t('relative_key')}: {alt_key}")
+    print(f"{t('bpm')}: {features['bpm']:.2f}")
+    print(f"{t('energy')}: {features['energy']:.2f} ({describe_score(features['energy'])})")
+    print(f"{t('danceability')}: {features['danceability']:.2f} ({describe_score(features['danceability'])})")
+    print(f"{t('happiness')}: {features['happiness']:.2f} ({describe_score(features['happiness'])})")
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+yt-dlp
+librosa
+numpy
+tkinterdnd2
+pyinstaller

--- a/youtube_audio.py
+++ b/youtube_audio.py
@@ -1,0 +1,48 @@
+import os
+import subprocess
+from typing import Optional
+
+def download_audio(url: str, bitrate: int = 160, output_dir: str = "downloads") -> str:
+    """Download a YouTube video's audio as an MP3 file.
+
+    Parameters
+    ----------
+    url: str
+        The YouTube URL to download.
+    bitrate: int, optional
+        MP3 bitrate in kbps. Supported values: 160 or 320.
+    output_dir: str, optional
+        Directory where the resulting MP3 will be saved.
+
+    Returns
+    -------
+    str
+        Path to the downloaded MP3 file.
+    """
+    if bitrate not in (160, 320):
+        raise ValueError("bitrate must be 160 or 320 kbps")
+
+    os.makedirs(output_dir, exist_ok=True)
+    output_template = os.path.join(output_dir, "%(title)s.%(ext)s")
+
+    cmd = [
+        "yt-dlp",
+        "-x",  # extract audio
+        "--audio-format",
+        "mp3",
+        "--audio-quality",
+        f"{bitrate}k",
+        "-o",
+        output_template,
+        url,
+    ]
+
+    subprocess.run(cmd, check=True)
+
+    # After downloading, find the most recent file in the directory
+    files = [os.path.join(output_dir, f) for f in os.listdir(output_dir)]
+    files = [f for f in files if f.endswith(".mp3")]
+    if not files:
+        raise FileNotFoundError("No MP3 file was created")
+    latest_file = max(files, key=os.path.getctime)
+    return latest_file


### PR DESCRIPTION
## Summary
- add English/Spanish translation module with `--lang` flag and localized GUI
- include `build.py` and PyInstaller dependency for creating Windows/Linux executables
- document language selection and build steps in README

## Testing
- `python -m py_compile main.py youtube_audio.py key_finder.py audio_features.py gui.py i18n.py build.py`


------
https://chatgpt.com/codex/tasks/task_e_689c3d8e58888327b3767ed5ffee76cb